### PR TITLE
PDesireAudio 6.0 for WCD9330

### DIFF
--- a/sound/soc/codecs/pdesireaudio.h
+++ b/sound/soc/codecs/pdesireaudio.h
@@ -1,0 +1,18 @@
+/* Copyright (C) 2016-2017 Tristan Marsell (tristan.marsell@t-online.de). All rights reserved.
+ * Copyright (C) 2016-2017 Team Project Desire. All rights reserved.
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+ 
+#include "wcd9xxx-resmgr.h"
+
+extern void pdesireaudio_advanced_mode_disable(struct snd_soc_codec *codec);
+
+extern void pdesireaudio_advanced_mode_enable(struct snd_soc_codec *codec);

--- a/sound/soc/codecs/wcd9330.c
+++ b/sound/soc/codecs/wcd9330.c
@@ -1,4 +1,12 @@
 /* Copyright (c) 2012-2015, The Linux Foundation. All rights reserved.
+ * Copyright (C) 2017 Tristan Marsell (tristan.marsell@t-online.de). All rights reserved.
+ * Copyright (C) 2017 Team Project Desire. All rights reserved.
+ * 
+ * PDesireAudio WCD9330 Tomtom Audio Driver
+ * Copyright (C) 2017 Tristan Marsell (tristan.marsell@t-online.de). All rights reserved.
+ * Copyright (C) 2017 Team Project Desire. All rights reserved.
+ *
+ * NOTE: This file is licensed under GPL v2 also with modifications.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -8,8 +16,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- */
-/*
+ *
  * NOTE: This file has been modified by Sony Mobile Communications Inc.
  * Modifications are Copyright (c) 2014 Sony Mobile Communications Inc,
  * and licensed under the license of the file.
@@ -44,6 +51,7 @@
 #include "wcd9xxx-common.h"
 #include "wcdcal-hwdep.h"
 #include "wcd_cpe_core.h"
+#include "pdesireaudio.h"
 
 enum {
 	VI_SENSE_1,
@@ -95,10 +103,54 @@ MODULE_PARM_DESC(cpe_debug_mode, "boot cpe in debug mode");
 
 static atomic_t kp_tomtom_priv;
 
-static int high_perf_mode;
-module_param(high_perf_mode, int,
+/* Description of PDesireAudio UHQA Mode:
+ * The PDesireAudio Mode is based on the UHQA Mode from LA.BR.1.3.3_rb2.14 branch
+ * of the sonyxperiadev/kernel repository (https://github.com/sonyxperiadev/kernel)
+ * 
+ * It is more advanced than the normal UHQA mode and also include gains like Lineout and HPHL/HPHR
+ * It also enable PDesireAudio Advanced Mode automatically
+ * 
+ * To enable it you need to execute "echo 1 > /sys/modules/snd_soc_wcd9330/uhqa_mode_pdesireaudio" on your Android Device
+ * 
+ * This module was made with the help of @sonyxperiadev and @BlackSoulxxx (https://github.com/BlackSoulxxx/XerXes/sound/soc/codecs/wcd9xxx-common.c)
+ * Mainatained by Tristan Marsell (tristan.marsell@t.online.de)
+ * Github: PDesire (https://github.com/PDesire) 
+ */
+
+static int uhqa_mode_pdesireaudio = 1;
+module_param(uhqa_mode_pdesireaudio, int,
 			S_IRUGO | S_IWUSR | S_IWGRP);
-MODULE_PARM_DESC(high_perf_mode, "enable/disable class AB config for hph");
+MODULE_PARM_DESC(uhqa_mode_pdesireaudio, "PDesireAudio UHQA Audio output switch");
+
+int pdesireaudio_start(void) 
+{
+	uhqa_mode_pdesireaudio = 1;
+	return 0;
+}
+
+int pdesireaudio_remove(void) 
+{
+	uhqa_mode_pdesireaudio = 0;
+	return 0;
+} 
+
+int pdesireaudio_init(void) 
+{
+	bool active;
+	
+	if (!uhqa_mode_pdesireaudio)
+		active = false;
+	else 
+		active = true;
+	
+	
+	pdesireaudio_remove();
+	
+	if (active == true)
+		pdesireaudio_start();
+	
+	return 0;
+}
 
 static struct afe_param_slimbus_slave_port_cfg tomtom_slimbus_slave_port_cfg = {
 	.minor_version = 1,
@@ -890,6 +942,30 @@ static uint32_t get_iir_band_coeff(struct snd_soc_codec *codec,
 	return value;
 }
 
+void pdesireaudio_advanced_mode_enable(struct snd_soc_codec *codec)
+{
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B1_CTL, TOMTOM_A_CDC_COMP0_B1_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B2_CTL, TOMTOM_A_CDC_COMP0_B2_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B3_CTL, TOMTOM_A_CDC_COMP0_B3_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B4_CTL, TOMTOM_A_CDC_COMP0_B4_CTL__POR);		
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B5_CTL, TOMTOM_A_CDC_COMP0_B5_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B6_CTL, TOMTOM_A_CDC_COMP0_B6_CTL__POR);	
+		
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP1_B1_CTL, TOMTOM_A_CDC_COMP1_B1_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP1_B2_CTL, TOMTOM_A_CDC_COMP1_B2_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP1_B3_CTL, TOMTOM_A_CDC_COMP1_B3_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP1_B4_CTL, TOMTOM_A_CDC_COMP1_B4_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP1_B5_CTL, TOMTOM_A_CDC_COMP1_B5_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP1_B6_CTL, TOMTOM_A_CDC_COMP1_B6_CTL__POR);	
+		
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP2_B1_CTL, TOMTOM_A_CDC_COMP2_B1_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP2_B2_CTL, TOMTOM_A_CDC_COMP2_B2_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP2_B3_CTL, TOMTOM_A_CDC_COMP2_B3_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP2_B4_CTL, TOMTOM_A_CDC_COMP2_B4_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP2_B5_CTL, TOMTOM_A_CDC_COMP2_B5_CTL__POR);	
+	snd_soc_write(codec, TOMTOM_A_CDC_COMP2_B6_CTL, TOMTOM_A_CDC_COMP2_B6_CTL__POR);	
+}
+
 static int tomtom_get_iir_band_audio_mixer(
 					struct snd_kcontrol *kcontrol,
 					struct snd_ctl_elem_value *ucontrol)
@@ -999,13 +1075,14 @@ static int tomtom_put_iir_band_audio_mixer(
 static int tomtom_get_compander(struct snd_kcontrol *kcontrol,
 			       struct snd_ctl_elem_value *ucontrol)
 {
+	if (!uhqa_mode_pdesireaudio) {
+		struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
+		int comp = ((struct soc_multi_mixer_control *)
+				kcontrol->private_value)->shift;
+		struct tomtom_priv *tomtom = snd_soc_codec_get_drvdata(codec);
 
-	struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
-	int comp = ((struct soc_multi_mixer_control *)
-		    kcontrol->private_value)->shift;
-	struct tomtom_priv *tomtom = snd_soc_codec_get_drvdata(codec);
-
-	ucontrol->value.integer.value[0] = tomtom->comp_enabled[comp];
+		ucontrol->value.integer.value[0] = tomtom->comp_enabled[comp];
+	}
 	return 0;
 }
 
@@ -1017,13 +1094,21 @@ static int tomtom_set_compander(struct snd_kcontrol *kcontrol,
 	int comp = ((struct soc_multi_mixer_control *)
 		    kcontrol->private_value)->shift;
 	int value = ucontrol->value.integer.value[0];
+	bool comp_bypass;
+	
+	if (!uhqa_mode_pdesireaudio) {
+		comp_bypass = false;
+	} else {
+		comp_bypass = true;
+	}
 
 	pr_debug("%s: Compander %d enable current %d, new %d\n",
 		 __func__, comp, tomtom->comp_enabled[comp], value);
 	tomtom->comp_enabled[comp] = value;
 
 	if (comp == COMPANDER_1 &&
-			tomtom->comp_enabled[comp] == 1) {
+			tomtom->comp_enabled[comp] == 1 &&
+			comp_bypass == false) {
 		/* Wavegen to 5 msec */
 		snd_soc_write(codec, TOMTOM_A_RX_HPH_CNP_WG_CTL, 0xDB);
 		snd_soc_write(codec, TOMTOM_A_RX_HPH_CNP_WG_TIME, 0x2A);
@@ -1061,26 +1146,32 @@ static int tomtom_config_gain_compander(struct snd_soc_codec *codec,
 
 	switch (comp) {
 	case COMPANDER_0:
-		snd_soc_update_bits(codec, TOMTOM_A_SPKR_DRV1_GAIN,
-				    1 << 2, !enable << 2);
-		snd_soc_update_bits(codec, TOMTOM_A_SPKR_DRV2_GAIN,
-				    1 << 2, !enable << 2);
+		if (!uhqa_mode_pdesireaudio) {
+			snd_soc_update_bits(codec, TOMTOM_A_SPKR_DRV1_GAIN,
+						1 << 2, !enable << 2);
+			snd_soc_update_bits(codec, TOMTOM_A_SPKR_DRV2_GAIN,
+						1 << 2, !enable << 2);
+		}
 		break;
 	case COMPANDER_1:
-		snd_soc_update_bits(codec, TOMTOM_A_RX_HPH_L_GAIN,
-				    1 << 5, !enable << 5);
-		snd_soc_update_bits(codec, TOMTOM_A_RX_HPH_R_GAIN,
-				    1 << 5, !enable << 5);
+		if (!uhqa_mode_pdesireaudio) {
+			snd_soc_update_bits(codec, TOMTOM_A_RX_HPH_L_GAIN,
+					    1 << 5, !enable << 5);
+			snd_soc_update_bits(codec, TOMTOM_A_RX_HPH_R_GAIN,
+					    1 << 5, !enable << 5);
+		}
 		break;
 	case COMPANDER_2:
-		snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_1_GAIN,
-				    1 << 5, !enable << 5);
-		snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_3_GAIN,
-				    1 << 5, !enable << 5);
-		snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_2_GAIN,
-				    1 << 5, !enable << 5);
-		snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_4_GAIN,
-				    1 << 5, !enable << 5);
+		if (!uhqa_mode_pdesireaudio) {
+			snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_1_GAIN,
+					    1 << 5, !enable << 5);
+			snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_3_GAIN,
+					    1 << 5, !enable << 5);
+			snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_2_GAIN,
+					    1 << 5, !enable << 5);
+			snd_soc_update_bits(codec, TOMTOM_A_RX_LINE_4_GAIN,
+					    1 << 5, !enable << 5);
+		}
 		break;
 	default:
 		WARN_ON(1);
@@ -1092,11 +1183,13 @@ static int tomtom_config_gain_compander(struct snd_soc_codec *codec,
 
 static void tomtom_discharge_comp(struct snd_soc_codec *codec, int comp)
 {
-	/* Level meter DIV Factor to 5*/
-	snd_soc_update_bits(codec, TOMTOM_A_CDC_COMP0_B2_CTL + (comp * 8), 0xF0,
-			    0x05 << 4);
-	/* RMS meter Sampling to 0x01 */
-	snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B3_CTL + (comp * 8), 0x01);
+	if (!uhqa_mode_pdesireaudio) {
+		/* Level meter DIV Factor to 5*/
+		snd_soc_update_bits(codec, TOMTOM_A_CDC_COMP0_B2_CTL + (comp * 8), 0xF0,
+					0x05 << 4);
+		/* RMS meter Sampling to 0x01 */
+		snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B3_CTL + (comp * 8), 0x01);
+	}
 
 	/* Worst case timeout for compander CnP sleep timeout */
 	usleep_range(3000, 3100);
@@ -1154,51 +1247,72 @@ static int tomtom_config_compander(struct snd_soc_dapm_widget *w,
 				 __func__);
 			break;
 		}
-		/* Set compander Sample rate */
-		snd_soc_update_bits(codec,
-				    TOMTOM_A_CDC_COMP0_FS_CFG + (comp * 8),
-				    0x07, rate);
-		/* Set the static gain offset for HPH Path */
-		if (comp == COMPANDER_1) {
-			if (buck_mv == WCD9XXX_CDC_BUCK_MV_2P15) {
-				snd_soc_update_bits(codec,
-					TOMTOM_A_CDC_COMP0_B4_CTL + (comp * 8),
-					0x80, 0x00);
-			} else {
-				snd_soc_update_bits(codec,
-					TOMTOM_A_CDC_COMP0_B4_CTL + (comp * 8),
-					0x80, 0x80);
+		/* Disable Compander fully */
+		if (!uhqa_mode_pdesireaudio) {
+			/* Set compander Sample rate */
+			snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_COMP0_FS_CFG + (comp * 8),
+						0x07, rate);
+			/* Set the static gain offset for HPH Path */
+			if (comp == COMPANDER_1) {
+				if (buck_mv == WCD9XXX_CDC_BUCK_MV_2P15) {
+					snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_COMP0_B4_CTL + (comp * 8),
+						0x80, 0x00);
+				} else {
+					snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_COMP0_B4_CTL + (comp * 8),
+						0x80, 0x80);
+				}
 			}
 		}
-		/* Enable RX interpolation path compander clocks */
-		snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_RX_B2_CTL,
-				    mask << comp_shift[comp],
-				    mask << comp_shift[comp]);
-		/* Toggle compander reset bits */
-		snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_OTHR_RESET_B2_CTL,
-				    mask << comp_shift[comp],
-				    mask << comp_shift[comp]);
-		snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_OTHR_RESET_B2_CTL,
-				    mask << comp_shift[comp], 0);
 
-		/* Set gain source to compander */
-		tomtom_config_gain_compander(codec, comp, true);
+		if (!uhqa_mode_pdesireaudio) {
+			/* Enable RX interpolation path compander clocks */
+			snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_RX_B2_CTL,
+						mask << comp_shift[comp],
+						mask << comp_shift[comp]);
+			/* Toggle compander reset bits */
+			snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_OTHR_RESET_B2_CTL,
+						mask << comp_shift[comp],
+						mask << comp_shift[comp]);
+			snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_OTHR_RESET_B2_CTL,
+						mask << comp_shift[comp], 0);
+
+			/* Set gain source to compander */
+			tomtom_config_gain_compander(codec, comp, true);
+		} else {
+			/* Enable RX interpolation path compander clocks */
+			snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_RX_B2_CTL,
+						mask << comp_shift[comp],
+						mask << comp_shift[comp]);
+			/* Toggle compander reset bits */
+			snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_OTHR_RESET_B2_CTL,
+						mask << comp_shift[comp],
+						mask << comp_shift[comp]);
+			snd_soc_update_bits(codec, TOMTOM_A_CDC_CLK_OTHR_RESET_B2_CTL,
+						mask << comp_shift[comp], 0);
+
+			/* Set gain source to compander */
+			tomtom_config_gain_compander(codec, comp, false);			
+		}
 
 		/* Compander enable */
 		snd_soc_update_bits(codec, TOMTOM_A_CDC_COMP0_B1_CTL +
 				    (comp * 8), enable_mask, enable_mask);
+		if (!uhqa_mode_pdesireaudio) {
+			tomtom_discharge_comp(codec, comp);
 
-		tomtom_discharge_comp(codec, comp);
-
-		/* Set sample rate dependent paramater */
-		snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B3_CTL + (comp * 8),
-			      comp_params->rms_meter_resamp_fact);
-		snd_soc_update_bits(codec,
-				    TOMTOM_A_CDC_COMP0_B2_CTL + (comp * 8),
-				    0xF0, comp_params->rms_meter_div_fact << 4);
-		snd_soc_update_bits(codec,
-					TOMTOM_A_CDC_COMP0_B2_CTL + (comp * 8),
-					0x0F, comp_params->peak_det_timeout);
+			/* Set sample rate dependent paramater */
+			snd_soc_write(codec, TOMTOM_A_CDC_COMP0_B3_CTL + (comp * 8),
+					  comp_params->rms_meter_resamp_fact);
+			snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_COMP0_B2_CTL + (comp * 8),
+						0xF0, comp_params->rms_meter_div_fact << 4);
+			snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_COMP0_B2_CTL + (comp * 8),
+						0x0F, comp_params->peak_det_timeout);
+		}
 		break;
 	case SND_SOC_DAPM_PRE_PMD:
 		/* Disable compander */
@@ -1337,6 +1451,8 @@ static const char *const tomtom_conn_mad_text[] = {
 static const struct soc_enum tomtom_conn_mad_enum =
 	SOC_ENUM_SINGLE_EXT(ARRAY_SIZE(tomtom_conn_mad_text),
 			tomtom_conn_mad_text);
+			
+			
 
 
 static int tomtom_mad_input_get(struct snd_kcontrol *kcontrol,
@@ -3076,10 +3192,17 @@ static int tomtom_codec_enable_lineout(struct snd_soc_dapm_widget *w,
 		snd_soc_update_bits(codec, lineout_gain_reg, 0x40, 0x40);
 		break;
 	case SND_SOC_DAPM_POST_PMU:
-		wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
-						 WCD9XXX_CLSH_STATE_LO,
+		if (!uhqa_mode_pdesireaudio) {
+			wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
+						 WCD9XXX_CLSH_STATE_HPHR,
 						 WCD9XXX_CLSH_REQ_ENABLE,
 						 WCD9XXX_CLSH_EVENT_POST_PA);
+		} else {
+			pdesireaudio_uhqa_mode(codec, &tomtom->clsh_d,
+						tomtom->uhqa_mode,
+						WCD9XXX_CLSAB_STATE_HPHR,
+						WCD9XXX_CLSAB_REQ_ENABLE);
+		}
 		pr_debug("%s: sleeping 5 ms after %s PA turn on\n",
 				__func__, w->name);
 		/* Wait for CnP time after PA enable */
@@ -4432,14 +4555,14 @@ static int tomtom_hphl_dac_event(struct snd_soc_dapm_widget *w,
 			tomtom_codec_enable_anc(w, kcontrol, event);
 			msleep(50);
 		}
-
-		if (!high_perf_mode && !tomtom_p->uhqa_mode) {
+		
+		if (!uhqa_mode_pdesireaudio) {
 			wcd9xxx_clsh_fsm(codec, &tomtom_p->clsh_d,
 						 WCD9XXX_CLSH_STATE_HPHL,
 						 WCD9XXX_CLSH_REQ_ENABLE,
 						 WCD9XXX_CLSH_EVENT_PRE_DAC);
 		} else {
-			wcd9xxx_enable_high_perf_mode(codec, &tomtom_p->clsh_d,
+			pdesireaudio_uhqa_mode(codec, &tomtom_p->clsh_d,
 						tomtom_p->uhqa_mode,
 						WCD9XXX_CLSAB_STATE_HPHL,
 						WCD9XXX_CLSAB_REQ_ENABLE);
@@ -4461,13 +4584,13 @@ static int tomtom_hphl_dac_event(struct snd_soc_dapm_widget *w,
 		snd_soc_update_bits(codec, TOMTOM_A_CDC_RX1_B4_CTL, 0x30, 0x00);
 		break;
 	case SND_SOC_DAPM_POST_PMD:
-		if (!high_perf_mode && !tomtom_p->uhqa_mode) {
+		if (!uhqa_mode_pdesireaudio) {
 			wcd9xxx_clsh_fsm(codec, &tomtom_p->clsh_d,
 						 WCD9XXX_CLSH_STATE_HPHL,
 						 WCD9XXX_CLSH_REQ_DISABLE,
 						 WCD9XXX_CLSH_EVENT_POST_PA);
 		} else {
-			wcd9xxx_enable_high_perf_mode(codec, &tomtom_p->clsh_d,
+			pdesireaudio_uhqa_mode(codec, &tomtom_p->clsh_d,
 						tomtom_p->uhqa_mode,
 						WCD9XXX_CLSAB_STATE_HPHL,
 						WCD9XXX_CLSAB_REQ_DISABLE);
@@ -4493,13 +4616,13 @@ static int tomtom_hphr_dac_event(struct snd_soc_dapm_widget *w,
 		}
 
 		snd_soc_update_bits(codec, w->reg, 0x40, 0x40);
-		if (!high_perf_mode && !tomtom_p->uhqa_mode) {
+		if (!uhqa_mode_pdesireaudio) {
 			wcd9xxx_clsh_fsm(codec, &tomtom_p->clsh_d,
 						 WCD9XXX_CLSH_STATE_HPHR,
 						 WCD9XXX_CLSH_REQ_ENABLE,
 						 WCD9XXX_CLSH_EVENT_PRE_DAC);
 		} else {
-			wcd9xxx_enable_high_perf_mode(codec, &tomtom_p->clsh_d,
+			pdesireaudio_uhqa_mode(codec, &tomtom_p->clsh_d,
 						tomtom_p->uhqa_mode,
 						WCD9XXX_CLSAB_STATE_HPHR,
 						WCD9XXX_CLSAB_REQ_ENABLE);
@@ -4515,13 +4638,13 @@ static int tomtom_hphr_dac_event(struct snd_soc_dapm_widget *w,
 		break;
 	case SND_SOC_DAPM_POST_PMD:
 		snd_soc_update_bits(codec, w->reg, 0x40, 0x00);
-		if (!high_perf_mode && !tomtom_p->uhqa_mode) {
+		if (!uhqa_mode_pdesireaudio) {
 			wcd9xxx_clsh_fsm(codec, &tomtom_p->clsh_d,
 						 WCD9XXX_CLSH_STATE_HPHR,
 						 WCD9XXX_CLSH_REQ_DISABLE,
 						 WCD9XXX_CLSH_EVENT_POST_PA);
 		} else {
-			wcd9xxx_enable_high_perf_mode(codec, &tomtom_p->clsh_d,
+			pdesireaudio_uhqa_mode(codec, &tomtom_p->clsh_d,
 						tomtom_p->uhqa_mode,
 						WCD9XXX_CLSAB_STATE_HPHR,
 						WCD9XXX_CLSAB_REQ_DISABLE);
@@ -4556,8 +4679,10 @@ static int tomtom_hph_pa_event(struct snd_soc_dapm_widget *w,
 		return -EINVAL;
 	}
 
-	if (tomtom->comp_enabled[COMPANDER_1])
-		pa_settle_time = TOMTOM_HPH_PA_SETTLE_COMP_ON;
+	if (!uhqa_mode_pdesireaudio) {
+		if (tomtom->comp_enabled[COMPANDER_1])
+			pa_settle_time = TOMTOM_HPH_PA_SETTLE_COMP_ON;
+	}
 
 	switch (event) {
 	case SND_SOC_DAPM_PRE_PMU:
@@ -4598,7 +4723,7 @@ static int tomtom_hph_pa_event(struct snd_soc_dapm_widget *w,
 				w->shift);
 			return -EINVAL;
 		}
-		if (!high_perf_mode && !tomtom->uhqa_mode) {
+		if (!uhqa_mode_pdesireaudio) {
 			wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
 						 req_clsh_state,
 						 WCD9XXX_CLSH_REQ_ENABLE,
@@ -4706,19 +4831,23 @@ static int tomtom_lineout_dac_event(struct snd_soc_dapm_widget *w,
 
 	switch (event) {
 	case SND_SOC_DAPM_PRE_PMU:
-		wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
+		if (!uhqa_mode_pdesireaudio) {
+			wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
 						 WCD9XXX_CLSH_STATE_LO,
 						 WCD9XXX_CLSH_REQ_ENABLE,
 						 WCD9XXX_CLSH_EVENT_PRE_DAC);
+		} 
 		snd_soc_update_bits(codec, w->reg, 0x40, 0x40);
 		break;
 
 	case SND_SOC_DAPM_POST_PMD:
 		snd_soc_update_bits(codec, w->reg, 0x40, 0x00);
-		wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
+		if (!uhqa_mode_pdesireaudio) {
+			wcd9xxx_clsh_fsm(codec, &tomtom->clsh_d,
 						 WCD9XXX_CLSH_STATE_LO,
 						 WCD9XXX_CLSH_REQ_DISABLE,
 						 WCD9XXX_CLSH_EVENT_POST_PA);
+		}
 		break;
 	}
 	return 0;
@@ -5780,7 +5909,7 @@ static int tomtom_set_channel_map(struct snd_soc_dai *dai,
 	struct tomtom_priv *tomtom = snd_soc_codec_get_drvdata(dai->codec);
 	struct wcd9xxx *core = dev_get_drvdata(dai->codec->dev->parent);
 	if (!tx_slot || !rx_slot) {
-		pr_err("%s: Invalid tx_slot=%pK, rx_slot=%pK\n",
+		pr_err("%s: Invalid tx_slot=%p, rx_slot=%p\n",
 			__func__, tx_slot, rx_slot);
 		return -EINVAL;
 	}
@@ -5816,7 +5945,7 @@ static int tomtom_get_channel_map(struct snd_soc_dai *dai,
 	case AIF2_PB:
 	case AIF3_PB:
 		if (!rx_slot || !rx_num) {
-			pr_err("%s: Invalid rx_slot %pK or rx_num %pK\n",
+			pr_err("%s: Invalid rx_slot %p or rx_num %p\n",
 				 __func__, rx_slot, rx_num);
 			return -EINVAL;
 		}
@@ -5835,7 +5964,7 @@ static int tomtom_get_channel_map(struct snd_soc_dai *dai,
 	case AIF4_VIFEED:
 	case AIF4_MAD_TX:
 		if (!tx_slot || !tx_num) {
-			pr_err("%s: Invalid tx_slot %pK or tx_num %pK\n",
+			pr_err("%s: Invalid tx_slot %p or tx_num %p\n",
 				 __func__, tx_slot, tx_num);
 			return -EINVAL;
 		}
@@ -6265,6 +6394,16 @@ static int tomtom_hw_params(struct snd_pcm_substream *substream,
 					TOMTOM_A_CDC_CLK_RX_I2S_CTL,
 					0x20, 0x20);
 				break;
+			case SNDRV_PCM_FORMAT_S24_LE:
+				if (!uhqa_mode_pdesireaudio) {
+					snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_CLK_RX_I2S_CTL,
+						0x20, 0x20);
+				} else {
+					snd_soc_update_bits(codec,
+						TOMTOM_A_CDC_CLK_RX_I2S_CTL,
+						0x20, 0x00);
+				}
 			case SNDRV_PCM_FORMAT_S32_LE:
 				snd_soc_update_bits(codec,
 					TOMTOM_A_CDC_CLK_RX_I2S_CTL,
@@ -8594,7 +8733,7 @@ static void tomtom_compute_impedance(struct wcd9xxx_mbhc *mbhc, s16 *l, s16 *r,
 	struct tomtom_priv *tomtom;
 
 	if (!mbhc) {
-		pr_err("%s: Invalid parameters mbhc = %pK\n",
+		pr_err("%s: Invalid parameters mbhc = %p\n",
 			__func__,  mbhc);
 		return;
 	}
@@ -8653,7 +8792,7 @@ static void tomtom_zdet_error_approx(struct wcd9xxx_mbhc *mbhc, uint32_t *zl,
 	const int shift = TOMTOM_ZDET_ERROR_APPROX_SHIFT;
 
 	if (!zl || !zr || !mbhc) {
-		pr_err("%s: Invalid parameters zl = %pK zr = %pK, mbhc = %pK\n",
+		pr_err("%s: Invalid parameters zl = %p zr = %p, mbhc = %p\n",
 			__func__, zl, zr, mbhc);
 		return;
 	}
@@ -8809,6 +8948,8 @@ static int tomtom_post_reset_cb(struct wcd9xxx *wcd9xxx)
 	struct snd_soc_codec *codec;
 	struct tomtom_priv *tomtom;
 	int rco_clk_rate;
+	
+	pdesireaudio_init();
 
 	codec = (struct snd_soc_codec *)(wcd9xxx->ssr_priv);
 	tomtom = snd_soc_codec_get_drvdata(codec);
@@ -9075,7 +9216,9 @@ static int tomtom_codec_probe(struct snd_soc_codec *codec)
 	int i, rco_clk_rate;
 	void *ptr = NULL;
 	struct wcd9xxx_core_resource *core_res;
-
+	
+	pdesireaudio_init();
+	
 #ifdef CONFIG_SOUND_CONTROL_HAX_3_GPL
 	pr_info("tomtom codec probe...\n");
 	fauxsound_codec_ptr = codec;
@@ -9269,9 +9412,12 @@ err_nomem_slimch:
 	devm_kfree(codec->dev, tomtom);
 	return ret;
 }
+
 static int tomtom_codec_remove(struct snd_soc_codec *codec)
 {
 	struct tomtom_priv *tomtom = snd_soc_codec_get_drvdata(codec);
+	
+	pdesireaudio_remove();
 
 	WCD9XXX_BG_CLK_LOCK(&tomtom->resmgr);
 	atomic_set(&kp_tomtom_priv, 0);
@@ -9384,5 +9530,5 @@ static void __exit tomtom_codec_exit(void)
 module_init(tomtom_codec_init);
 module_exit(tomtom_codec_exit);
 
-MODULE_DESCRIPTION("TomTom codec driver");
+MODULE_DESCRIPTION("PDesireAudio TomTom codec driver");
 MODULE_LICENSE("GPL v2");

--- a/sound/soc/codecs/wcd9xxx-common.c
+++ b/sound/soc/codecs/wcd9xxx-common.c
@@ -17,6 +17,7 @@
 #include <linux/delay.h>
 #include <linux/mfd/wcd9xxx/wcd9xxx_registers.h>
 #include "wcd9xxx-common.h"
+#include "pdesireaudio.h"
 
 #define CLSH_COMPUTE_EAR 0x01
 #define CLSH_COMPUTE_HPH_L 0x02
@@ -543,58 +544,6 @@ static void wcd9xxx_chargepump_request(struct snd_soc_codec *codec, bool on)
 		}
 	}
 }
-
-void wcd9xxx_enable_high_perf_mode(struct snd_soc_codec *codec,
-				struct wcd9xxx_clsh_cdc_data *clsh_d,
-				u8 uhqa_mode, u8 req_state, bool req_type)
-{
-	dev_dbg(codec->dev, "%s: users fclk8 %d, fclk5 %d", __func__,
-			clsh_d->ncp_users[NCP_FCLK_LEVEL_8],
-			clsh_d->ncp_users[NCP_FCLK_LEVEL_5]);
-
-	if (req_type == WCD9XXX_CLSAB_REQ_ENABLE) {
-		clsh_d->ncp_users[NCP_FCLK_LEVEL_8]++;
-		snd_soc_write(codec, WCD9XXX_A_RX_HPH_BIAS_PA,
-					WCD9XXX_A_RX_HPH_BIAS_PA__POR);
-		snd_soc_write(codec, WCD9XXX_A_RX_HPH_L_PA_CTL, 0x48);
-		snd_soc_write(codec, WCD9XXX_A_RX_HPH_R_PA_CTL, 0x48);
-		if (uhqa_mode)
-			snd_soc_update_bits(codec, WCD9XXX_A_RX_HPH_CHOP_CTL,
-						0x20, 0x00);
-		wcd9xxx_chargepump_request(codec, true);
-		wcd9xxx_enable_anc_delay(codec, true);
-		wcd9xxx_enable_buck(codec, clsh_d, false);
-		if (clsh_d->ncp_users[NCP_FCLK_LEVEL_8] > 0)
-			snd_soc_update_bits(codec, WCD9XXX_A_NCP_STATIC,
-						0x0F, 0x08);
-		snd_soc_update_bits(codec, WCD9XXX_A_NCP_STATIC, 0x30, 0x30);
-
-		/* Enable NCP and wait until settles down */
-		if (snd_soc_update_bits(codec, WCD9XXX_A_NCP_EN, 0x01, 0x01))
-			usleep_range(NCP_SETTLE_TIME_US, NCP_SETTLE_TIME_US+10);
-	} else {
-		snd_soc_update_bits(codec, WCD9XXX_A_RX_HPH_CHOP_CTL,
-					0x20, 0x20);
-		snd_soc_write(codec, WCD9XXX_A_RX_HPH_L_PA_CTL,
-					WCD9XXX_A_RX_HPH_L_PA_CTL__POR);
-		snd_soc_write(codec, WCD9XXX_A_RX_HPH_R_PA_CTL,
-					WCD9XXX_A_RX_HPH_R_PA_CTL__POR);
-		snd_soc_write(codec, WCD9XXX_A_RX_HPH_BIAS_PA, 0x57);
-		wcd9xxx_enable_buck(codec, clsh_d, true);
-		wcd9xxx_chargepump_request(codec, false);
-		wcd9xxx_enable_anc_delay(codec, false);
-		clsh_d->ncp_users[NCP_FCLK_LEVEL_8]--;
-		if (clsh_d->ncp_users[NCP_FCLK_LEVEL_8] == 0 &&
-		    clsh_d->ncp_users[NCP_FCLK_LEVEL_5] == 0)
-			snd_soc_update_bits(codec, WCD9XXX_A_NCP_EN,
-						0x01, 0x00);
-		else if (clsh_d->ncp_users[NCP_FCLK_LEVEL_8] == 0)
-			snd_soc_update_bits(codec, WCD9XXX_A_NCP_STATIC,
-						0x0F, 0x05);
-	}
-	dev_dbg(codec->dev, "%s: leave\n", __func__);
-}
-EXPORT_SYMBOL(wcd9xxx_enable_high_perf_mode);
 
 static int get_impedance_index(u32 imped)
 {
@@ -1214,6 +1163,65 @@ static void wcd9xxx_clsh_state_hph_l(struct snd_soc_codec *codec,
 		wcd9xxx_chargepump_request(codec, false);
 	}
 }
+
+void pdesireaudio_uhqa_mode(struct snd_soc_codec *codec,
+				struct wcd9xxx_clsh_cdc_data *clsh_d,
+				u8 uhqa_mode, u8 req_state, bool req_type)
+{
+	dev_dbg(codec->dev, "%s: users fclk8 %d, fclk5 %d", __func__,
+			clsh_d->ncp_users[NCP_FCLK_LEVEL_8],
+			clsh_d->ncp_users[NCP_FCLK_LEVEL_5]);
+
+	if (req_type == WCD9XXX_CLSAB_REQ_ENABLE) {
+		clsh_d->ncp_users[NCP_FCLK_LEVEL_8]++;
+		snd_soc_write(codec, WCD9XXX_A_RX_HPH_BIAS_PA,
+					WCD9XXX_A_RX_HPH_BIAS_PA__POR);
+		snd_soc_write(codec, WCD9XXX_A_RX_HPH_L_PA_CTL, 0x48);
+		snd_soc_write(codec, WCD9XXX_A_RX_HPH_R_PA_CTL, 0x48);
+		if (uhqa_mode)
+			snd_soc_update_bits(codec, WCD9XXX_A_RX_HPH_CHOP_CTL,
+						0x20, 0x00);
+		wcd9xxx_chargepump_request(codec, true);
+		wcd9xxx_enable_anc_delay(codec, true);
+		wcd9xxx_enable_buck(codec, clsh_d, false);
+		wcd9xxx_clsh_comp_req(codec, clsh_d, CLSH_COMPUTE_HPH_R, false);
+		wcd9xxx_clsh_comp_req(codec, clsh_d, CLSH_COMPUTE_HPH_L, false);		
+		wcd9xxx_enable_clsh_block(codec, clsh_d, false);
+		if (clsh_d->ncp_users[NCP_FCLK_LEVEL_8] > 0)
+			snd_soc_update_bits(codec, WCD9XXX_A_NCP_STATIC,
+						0x0F, 0x08);
+		snd_soc_update_bits(codec, WCD9XXX_A_NCP_STATIC, 0x30, 0x30);
+
+		/* Enable NCP and wait until settles down */
+		if (snd_soc_update_bits(codec, WCD9XXX_A_NCP_EN, 0x01, 0x01))
+			usleep_range(NCP_SETTLE_TIME_US, NCP_SETTLE_TIME_US+10);
+		pdesireaudio_advanced_mode_enable(codec);
+	} else {
+		snd_soc_update_bits(codec, WCD9XXX_A_RX_HPH_CHOP_CTL,
+					0x20, 0x20);
+		snd_soc_write(codec, WCD9XXX_A_RX_HPH_L_PA_CTL,
+					WCD9XXX_A_RX_HPH_L_PA_CTL__POR);
+		snd_soc_write(codec, WCD9XXX_A_RX_HPH_R_PA_CTL,
+					WCD9XXX_A_RX_HPH_R_PA_CTL__POR);
+		snd_soc_write(codec, WCD9XXX_A_RX_HPH_BIAS_PA, 0x57);
+		wcd9xxx_enable_buck(codec, clsh_d, true);
+		wcd9xxx_chargepump_request(codec, false);
+		wcd9xxx_enable_anc_delay(codec, false);
+		wcd9xxx_enable_clsh_block(codec, clsh_d, true);
+		wcd9xxx_clsh_comp_req(codec, clsh_d, CLSH_COMPUTE_HPH_R, true);
+		wcd9xxx_clsh_comp_req(codec, clsh_d, CLSH_COMPUTE_HPH_L, true);
+		clsh_d->ncp_users[NCP_FCLK_LEVEL_8]--;
+		if (clsh_d->ncp_users[NCP_FCLK_LEVEL_8] == 0 &&
+		    clsh_d->ncp_users[NCP_FCLK_LEVEL_5] == 0)
+			snd_soc_update_bits(codec, WCD9XXX_A_NCP_EN,
+						0x01, 0x00);
+		else if (clsh_d->ncp_users[NCP_FCLK_LEVEL_8] == 0)
+			snd_soc_update_bits(codec, WCD9XXX_A_NCP_STATIC,
+						0x0F, 0x05);
+	}
+	dev_dbg(codec->dev, "%s: leave\n", __func__);
+}
+EXPORT_SYMBOL(pdesireaudio_uhqa_mode);
 
 static void wcd9xxx_clsh_state_hph_r(struct snd_soc_codec *codec,
 		struct wcd9xxx_clsh_cdc_data *clsh_d,

--- a/sound/soc/msm/qdsp6v2/msm-compr-q6-v2.c
+++ b/sound/soc/msm/qdsp6v2/msm-compr-q6-v2.c
@@ -93,9 +93,9 @@ static struct snd_pcm_hardware msm_compr_hardware_playback = {
 				SNDRV_PCM_INFO_INTERLEAVED |
 				SNDRV_PCM_INFO_PAUSE | SNDRV_PCM_INFO_RESUME),
 	.formats =	      SNDRV_PCM_FMTBIT_S16_LE | SNDRV_PCM_FMTBIT_S24_LE,
-	.rates =		SNDRV_PCM_RATE_8000_48000 | SNDRV_PCM_RATE_KNOT,
+	.rates =		SNDRV_PCM_RATE_8000_192000 | SNDRV_PCM_RATE_KNOT,
 	.rate_min =	     8000,
-	.rate_max =	     48000,
+	.rate_max =	     192000,
 	.channels_min =	 1,
 	.channels_max =	 8,
 	.buffer_bytes_max =     1024 * 1024,
@@ -108,7 +108,7 @@ static struct snd_pcm_hardware msm_compr_hardware_playback = {
 
 /* Conventional and unconventional sample rate supported */
 static unsigned int supported_sample_rates[] = {
-	8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000
+	8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 96000, 174000, 192000
 };
 
 /* Add supported codecs for compress capture path */


### PR DESCRIPTION
# **PDesireAudio 6.0 for WCD9330 Devices**

_Made by PDesire (<tristan.marsell@t-online.de>) and Team Project Desire_

PDesireAudio 6.0 is an advanced way of the WCD9330 High Performance Mode, together with some minor audio patches

## Explaination of the Commits

Update wcd9330.c, wcd9xxx-common.c and create pdesireaudio.h (c486461, 09ac63c & d453b45) are commits which adds the main core of PDesireAudio, this adds a bypass for Companders (COMP) and advanced way of the High Performance mode, and some audio patches to improve audio playback

Update msm-compr-q6-v2.c (5edeeb7) is a commit where compress stream gets possibillity to playback 192kHz 


These patches are tested on Kitakami devices, but theoretically it's working on all WCD9330 kernels with High Performance Mode
